### PR TITLE
Potential fix for code scanning alert no. 57: Incomplete multi-character sanitization

### DIFF
--- a/src/app/admin/media/edit/actions.ts
+++ b/src/app/admin/media/edit/actions.ts
@@ -150,7 +150,10 @@ export async function saveArticle(formData: FormData) {
           content,
           status,
           thumbnail_url: thumbnailUrl,
-          excerpt: content.replace(/<[^>]*>/g, '').substring(0, 200),
+          excerpt: sanitizeHtml(content, {
+            allowedTags: [],
+            allowedAttributes: {},
+          }).substring(0, 200),
           published_at:
             status === 'PUBLISHED' ? new Date().toISOString() : null,
         })


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/57](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/57)

The best way to fix this problem is to use the same well-tested sanitization library (`sanitize-html`) for both article insertion and update. Specifically, replace the excerpt calculation on line 153 (which currently uses a single-pass regex) with a call to `sanitizeHtml(content, { allowedTags: [], allowedAttributes: {} })`, followed by truncation. This ensures robust, consistent, and secure HTML stripping.  
The edit is on line 153, within the insert branch for new articles. No new imports or dependencies are needed, as `sanitize-html` is already imported at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
