### PR TITLE
Potential fix for code scanning alert no. 29: Clear text storage of sensitive information

### DIFF
--- a/src/app/company/job/[job_id]/edit/JobEditClient.tsx
+++ b/src/app/company/job/[job_id]/edit/JobEditClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import CryptoJS from 'crypto-js';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import JobEditHeader from './JobEditHeader';
@@ -64,6 +65,14 @@ export default function JobEditClient({
   currentUserId 
 }: JobEditClientProps) {
   const router = useRouter();
+
+  // Encryption key for demonstration; in production, securely manage this!
+  const ENCRYPTION_KEY = 'YOUR_SECURE_KEY_HERE';
+
+  // AES encryption for sensitive data
+  function encrypt(text: string): string {
+    return CryptoJS.AES.encrypt(text, ENCRYPTION_KEY).toString();
+  }
 
   // 確認画面の表示制御
 
@@ -348,8 +357,8 @@ export default function JobEditClient({
       positionSummary: positionSummary || '',
       requiredSkills: skills || '',
       preferredSkills: otherRequirements || '',
-      salaryMin: salaryMin,
-      salaryMax: salaryMax,
+      salaryMin: encrypt(salaryMin),
+      salaryMax: encrypt(salaryMax),
       salaryNote: salaryNote || '',
       employmentType: employmentType || '未設定',
       work_locations: locations || [],


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/29](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/29)

The best way to fix this issue is to ensure that sensitive information (in this case, salaryMin and salaryMax, and potentially other sensitive fields) is encrypted before storing it in browser storage like `sessionStorage`. To do this, we should update the block that prepares `editData` before saving to `sessionStorage`: encrypt salary information prior to serialization, using a symmetric key that is only available in the current user's session (for example, a key stored in a variable or generated at login and kept in memory). We'll use a well-known crypto library like `crypto-js` for frontend encryption with AES. We must add the import for `crypto-js`, define a simple `encrypt` function, and update the relevant storage call to save the encrypted values. Since we can only edit code within the file shown, we will not handle key management, and will use a hardcoded key for demonstration purposes–in production, the key must be managed securely.

Specifically:
- Add an import for `crypto-js`.
- Define an `encrypt` function (AES-based).
- Replace the values of `salaryMin` and `salaryMax` in the `editData` object with their encrypted forms prior to serialization/storage.
- Ensure only these fields are encrypted (unless other fields are identified as sensitive).
- No other structural changes to state or logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
