### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/src/app/admin/media/new/actions.ts
+++ b/src/app/admin/media/new/actions.ts
@@ -97,7 +97,7 @@ export async function saveArticle(formData: FormData) {
         content,
         status,
         thumbnail_url: thumbnailUrl,
-        excerpt: content.replace(/<[^>]*>/g, '').substring(0, 200),
+        excerpt: (() => { let s = content; let prev; do { prev = s; s = s.replace(/<[^>]*>/g, ''); } while (s !== prev); return s.substring(0, 200); })(),
         published_at: status === 'PUBLISHED' ? new Date().toISOString() : null,
       })
       .select()


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/5](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/5)

The best way to fix this problem is to replace the fragile regex tag remover (`content.replace(/<[^>]*>/g, '')`), which can incompletely remove HTML tags, with a well-tested sanitization library like `sanitize-html` (which keeps only safe HTML) or, if libraries cannot be used, apply the regex replacement repeatedly until no further tags are found (do-while loop). Since we are only allowed to modify this snippet and should avoid changing functionality significantly, the best lightweight fix is to wrap the regex replacement in a loop so it removes every tag, even if they overlap or are nested in a way that would defeat a single-pass regex.

Specifically, on line 100 in `src/app/admin/media/new/actions.ts`, replace:
```ts
content.replace(/<[^>]*>/g, '').substring(0, 200)
```
with:
```ts
(() => { let s = content; let prev; do { prev = s; s = s.replace(/<[^>]*>/g, ''); } while (s !== prev); return s.substring(0, 200); })()
```
This repeatedly removes HTML tags until none remain, then generates the excerpt as before. No extra imports are required; if the project already allows using outside libraries like `sanitize-html`, a better fix would use that, but for minimal code change, this loop is effective and safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
