### PR TITLE
Potential fix for code scanning alert no. 58: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dompurify": "^3.2.6",
     "inversify": "^7.9.1",
     "jose": "^5.10.0",
     "lucide-react": "^0.544.0",
@@ -48,14 +47,14 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.62.0",
     "reflect-metadata": "^0.2.2",
-    "sanitize-html": "^2.17.0",
     "tailwind-merge": "^3.3.1",
     "winston": "^3.17.0",
     "zod": "^3.25.67",
     "zustand": "^5.0.6",
     "sanitize-html": "^2.17.0",
     "crypto-js": "^4.2.0",
-    "dompurify": "^3.2.6"
+    "dompurify": "^3.2.6",
+    "html-to-text": "^9.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/lib/email/sender.ts
+++ b/src/lib/email/sender.ts
@@ -2,7 +2,7 @@
 
 import sgMail from '@sendgrid/mail';
 import { logger } from '@/lib/server/utils/logger';
-
+import { htmlToText } from 'html-to-text';
 // SendGrid API設定
 if (process.env.SENDGRID_API_KEY) {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY);
@@ -80,7 +80,7 @@ export async function sendEmailViaSendGrid(
       },
       subject: params.subject,
       html: params.html,
-      text: params.text || params.html.replace(/<[^>]*>/g, ''), // HTMLからテキスト生成
+      text: params.text || htmlToText(params.html), // HTMLからテキスト生成
     };
 
     // SendGrid経由で送信


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/58](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/58)

To robustly sanitize HTML for plain text emails, we should use a well-tested library to strip HTML tags and convert HTML to plain text. The package [`html-to-text`](https://www.npmjs.com/package/html-to-text) is widely used for this purpose, producing clean text output from arbitrary HTML input and properly handling edge cases, unlike a hand-written regex. The fix involves importing and using this library in place of the `.replace(/<[^>]*>/g, '')` approach to ensure all HTML tags—including dangerous constructs—are stripped, closing the security hole. Changes will be made only in `src/lib/email/sender.ts`, updating line 83 to use `htmlToText` and adding the necessary import. No other functionality or logic needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
