### PR TITLE
Potential fix for code scanning alert no. 28: Clear text storage of sensitive information

### DIFF
--- a/src/app/admin/notice/edit/preview/page.tsx
+++ b/src/app/admin/notice/edit/preview/page.tsx
@@ -46,7 +46,15 @@ export default function EditPreviewPage() {
     const fetchData = async () => {
       const storedData = sessionStorage.getItem('previewNotice');
       if (storedData) {
-        const data = JSON.parse(storedData);
+        let data;
+        try {
+          const decrypted = await decryptString(storedData);
+          data = JSON.parse(decrypted);
+        } catch (e) {
+          console.error('Failed to decrypt previewNotice', e);
+          router.push('/admin/notice/edit');
+          return;
+        }
 
         // カテゴリデータを取得してカテゴリ名の解決用に使用
         try {
@@ -107,7 +115,9 @@ export default function EditPreviewPage() {
     if (previewData) {
       const updatedData = { ...previewData, status: newStatus };
       setPreviewData(updatedData);
-      sessionStorage.setItem('previewNotice', JSON.stringify(updatedData));
+      encryptString(JSON.stringify(updatedData)).then(encrypted => {
+        sessionStorage.setItem('previewNotice', encrypted);
+      });
     }
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/28](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/28)

To remediate cleartext storage of sensitive information in `sessionStorage`, we should encrypt data before storing it, and decrypt it when reading it. As this is client-side code, a simple symmetric encryption solution is appropriate: use the well-known Web Crypto API for security (instead of custom/weak schemes). We'll introduce utility functions to encrypt and decrypt data, storing the ciphertext in sessionStorage instead of the plain JSON. As sessionStorage is short-lived and client-side only, a per-session generated key (kept in memory—a React state variable) is a reasonable approach (for improved UX, otherwise window.sessionStorage would lose key on reload; for demo, we can generate it at mount and keep in global var/state or window property).

**Steps**:
- Create helper methods for encryption/decryption using the SubtleCrypto API.
- Generate a random key on first use (e.g. at component mount) and store it in-memory.
- When writing to sessionStorage, encrypt the JSON string with the key, and store the ciphertext.
- When reading from sessionStorage, decrypt the ciphertext using the key and parse back to object.
- Ensure all existing read/write operations for `'previewNotice'` are updated to use encryption/decryption.

_edits needed_:  
- Add import for helper (or define helper functions) in `src/app/admin/notice/new/NoticeNewClient.tsx` (since that's where storage occurs).
- Update storage (line 161) and reading (lines ~43, ~46) to use encrypt/decrypt.
- Since decryption is also performed in `src/app/admin/notice/edit/preview/page.tsx`, corresponding changes must be made there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
