### PR TITLE
Potential fix for code scanning alert no. 63: Replacement of a substring with itself

### DIFF
--- a/src/app/admin/company/CompanyClient.tsx
+++ b/src/app/admin/company/CompanyClient.tsx
@@ -324,7 +324,6 @@ export default function CompanyClient({ companies }: Props) {
                                   hour: '2-digit',
                                   minute: '2-digit',
                                 })
-                                .replace(/\//g, '/')
                             : 'N/A'}
                         </div>
                       </div>


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/63](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/63)

The fix is to remove the redundant `.replace(/\//g, '/')` call entirely, as it does not alter the string produced by `.toLocaleString('ja-JP', {...})`. There is no reason to replace slashes (`/`) with themselves, so deleting this method call is the best way to resolve the error without changing existing functionality.

Changes needed:
- In `src/app/admin/company/CompanyClient.tsx`, locate line 327 and remove the `.replace(/\//g, '/')` from the expression, so it simply uses the result of `.toLocaleString(...)`.

No imports, definitions, or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
