### PR TITLE
Potential fix for code scanning alert no. 62: Replacement of a substring with itself

### DIFF
--- a/src/app/admin/company/CompanyClient.tsx
+++ b/src/app/admin/company/CompanyClient.tsx
@@ -133,7 +133,7 @@ export default function CompanyClient({ companies }: Props) {
               hour: '2-digit',
               minute: '2-digit',
             })
-            .replace(/\//g, '/')
+            // .replace(/\//g, '/') (removed: no-op)
         : 'N/A',
       company.last_login_user || 'N/A',
       company.group_names || 'N/A',
@@ -145,7 +145,7 @@ export default function CompanyClient({ companies }: Props) {
           hour: '2-digit',
           minute: '2-digit',
         })
-        .replace(/\//g, '/'),
+        // .replace(/\//g, '/') (removed: no-op)
     ]);
 
     // CSV形式に変換


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/62](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/62)

The best fix is to remove the unnecessary `.replace(/\//g, '/')` since it has no effect. If the intention was to format the date (for example, replacing `/` with `-` for YYYY-MM-DD), the replacement should be changed to `.replace(/\//g, '-')`.  
Review both occurrences (lines 136 and 148) of `.replace(/\//g, '/')` and either remove them or replace slashes with the desired character for correct date formatting. Unless there's a specific need for replacement, removing these calls preserves the original date formatting returned by `.toLocaleString('ja-JP', ...)`. This change is localized to the code generating CSV data for download.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
