### PR TITLE
Potential fix for code scanning alert no. 43: Replacement of a substring with itself

### DIFF
--- a/src/app/admin/job/pending/PendingTableClient.tsx
+++ b/src/app/admin/job/pending/PendingTableClient.tsx
@@ -43,8 +43,7 @@ function formatDateTime(iso: string): { date: string; time: string } {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
-    })
-    .replace(/\//g, '/');
+    });
   const time = d.toLocaleTimeString('ja-JP', {
     hour: '2-digit',
     minute: '2-digit',


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/43](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/43)

To fix the problem, we should remove the unnecessary `.replace(/\//g, '/')` operation from line 47 in the `formatDateTime` function, as it has no effect on the string returned by `toLocaleDateString`. This change will not modify any existing functionality because the replacement does nothing; it simply makes the code clearer and more efficient. The edit only needs to be made in the function definition in `src/app/admin/job/pending/PendingTableClient.tsx`, with no new imports or methods required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
