### PR TITLE
Potential fix for code scanning alert no. 53: Replacement of a substring with itself

### DIFF
--- a/src/components/company/CompanyTaskSidebar.tsx
+++ b/src/components/company/CompanyTaskSidebar.tsx
@@ -170,7 +170,7 @@ export function CompanyTaskSidebar({ className, showTodoAndNews = false, taskDat
                   year: 'numeric',
                   month: '2-digit',
                   day: '2-digit'
-                }).replace(/\//g, '/')
+                }).replace(/\//g, '-')
               });
             }
           }


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/53](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/53)

To fix this problem, we need to ensure that the `.replace()` call serves a meaningful purpose. Usually, if you want to modify the output of `toLocaleDateString`, it is to change the delimiter or to normalize the format. For instance, you may want to replace slashes `'/'` to hyphens `'-'`, dots `'.'`, or another character. In this case, the most sensible and safe default is to update the code to replace slashes with hyphens: `.replace(/\//g, '-')`. This will generate dates such as `"2024-06-01"`, which is a standard format and easy to read. 

If the intent was otherwise, such as removing slashes entirely or using a different separator, adjust accordingly, but hyphens are typical. The change is to be made in file `src/components/company/CompanyTaskSidebar.tsx` on line 173. No new methods, imports, or definitions are required—just correct the replacement string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
