### PR TITLE
Potential fix for code scanning alert no. 49: Replacement of a substring with itself

### DIFF
--- a/src/components/candidate/CandidateMessageLayoutServer.tsx
+++ b/src/components/candidate/CandidateMessageLayoutServer.tsx
@@ -59,7 +59,7 @@ async function getRoomsForCandidate(candidateId: string): Promise<CandidateRoom[
         day: '2-digit',
         hour: '2-digit',
         minute: '2-digit'
-      }).replace(/\//g, '/') : '',
+      }).replace(/\//g, '.') : '',
       unreadCount: unreadCount,
       isUnread: unreadCount > 0,
     });


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/49](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/49)

To fix the problem, replace the `.replace(/\//g, '/')` expression with a replacement that actually achieves its intended effect. Most likely, the intent was to change the date separator from slashes `/` to something else, such as a period `.` or hyphen `-`, which is customary in Japanese date display (e.g. `2024-06-01 12:34` or `2024.06.01 12:34`). Carefully change the replacement string from `'/'` to the correct separator. The only changes needed are in the code region of line 62 in src/components/candidate/CandidateMessageLayoutServer.tsx; no new methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
