### PR TITLE
Potential fix for code scanning alert no. 50: Replacement of a substring with itself

### DIFF
--- a/src/components/company/CandidateDetailModal.tsx
+++ b/src/components/company/CandidateDetailModal.tsx
@@ -38,8 +38,7 @@ const CandidateDetailModal: React.FC<CandidateDetailModalProps> = ({
           year: 'numeric',
           month: '2-digit',
           day: '2-digit',
-        })
-        .replace(/\//g, '/');
+        });
     } catch {
       return '未設定';
     }


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/50](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/50)

The best way to address this is to remove the `.replace(/\//g, '/');` line altogether, as it is a no-op and serves no functional purpose. Unless there is specific intent to replace `/` with another character (in which case, it should be changed to the appropriate replacement), the cleanest fix is simply to omit this redundant replacement. The only code change needed is to delete `.replace(/\//g, '/');` from the chain in `formatDate`, within `src/components/company/CandidateDetailModal.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
