### PR TITLE
Potential fix for code scanning alert no. 51: Replacement of a substring with itself

### DIFF
--- a/src/components/company/CandidateDetailTabDetail.tsx
+++ b/src/components/company/CandidateDetailTabDetail.tsx
@@ -30,8 +30,7 @@ const CandidateDetailTabDetail: React.FC<CandidateDetailTabDetailProps> = ({
           year: 'numeric',
           month: '2-digit',
           day: '2-digit',
-        })
-        .replace(/\//g, '/');
+        });
     } catch {
       return '未設定';
     }


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/51](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/51)

To fix the problem, simply remove the unnecessary `.replace(/\//g, '/')` call, as replacing '/' with itself does nothing. The intention seems to be to format the date string for display in the Japanese format (yyyy/mm/dd), and `toLocaleDateString('ja-JP', { ... })` already returns dates in that format with slashes. Thus, the replace call can be safely removed. Only line 34 needs to be changed (removed), keeping the rest of the function untouched for desired behavior.

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
