### PR TITLE
Potential fix for code scanning alert no. 66: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,4 +1,6 @@
 name: Deploy to AWS EC2
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/66](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/66)

To fix the problem, add an explicit `permissions` block specifying the least required privileges. In this workflow, only read access to repository contents is needed for the job to check out code. Add  
```yaml
permissions:
  contents: read
```  
either at the workflow root (above `jobs:`) to apply globally, or at the job level if there's a need for granularity (not apparent here). For clarity and global application, add it directly after the workflow `name` and before `on:` in `.github/workflows/deploy-aws.yml`. No additional libraries, imports, or changes are needed elsewhere, as this concerns workflow structure only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
