### PR TITLE
Potential fix for code scanning alert no. 65: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main, clean-slate]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/65](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/65)

The fix is to add a `permissions` block with minimal required permissions. Since the workflow only checks out code and runs scripts, it typically only needs `contents: read`. This can be set at the workflow root (above `jobs:`) to apply to all jobs unless they specify their own permissions.  
To implement the fix, insert the following at the top-level (before `jobs:`):  
```yaml
permissions:
  contents: read
```
This addition ensures the workflow and all its jobs only have the minimal read permissions on repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
