### PR TITLE
Potential fix for code scanning alert no. 38: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/admin/notice/preview/page.tsx
+++ b/src/app/admin/notice/preview/page.tsx
@@ -3,13 +3,13 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
+import DOMPurify from 'dompurify';
 import { Button } from '@/components/ui/button';
 import { AdminButton } from '@/components/admin/ui/AdminButton';
 import { AdminNotificationModal } from '@/components/admin/ui/AdminNotificationModal';
 import { AdminPageTitle } from '@/components/admin/AdminPageTitle';
 import { createClient } from '@/lib/supabase/client';
 import { createNotice, uploadNoticeThumbnail } from '../actions';
-
 interface PreviewData {
   title: string;
   categoryIds: string[];
@@ -302,7 +302,7 @@ export default function PreviewPage() {
               <div 
                 className="prose prose-lg max-w-none mb-[60px]"
                 style={{ paddingLeft: '0', paddingRight: '0' }}
-                dangerouslySetInnerHTML={{ __html: previewData.content }}
+                dangerouslySetInnerHTML={{ __html: previewData && previewData.content ? DOMPurify.sanitize(previewData.content) : '' }}
               />
 
               {/* お知らせ下のボタン */}


### PR DESCRIPTION
Potential fix for [https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/38](https://github.com/QueueCorpJP/mokin-recruit/security/code-scanning/38)

The best way to fix this issue is to sanitize all HTML content before passing it to `dangerouslySetInnerHTML`. This can be done using a popular sanitization library such as `dompurify`, which removes or encodes unsafe markup and scripts. The fix should be implemented at the point just before rendering: that is, in `src/app/admin/notice/preview/page.tsx`, sanitize `previewData.content` so that what is rendered cannot execute arbitrary scripts.

Specifically, you should:

- Import DOMPurify into `src/app/admin/notice/preview/page.tsx`.
- When setting the inner HTML content, run `previewData.content` through DOMPurify's `sanitize()` method before passing it to `dangerouslySetInnerHTML`.
- This means replacing `dangerouslySetInnerHTML={{ __html: previewData.content }}` with `dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(previewData.content) }}` (handling the null-checks appropriately).

No changes are needed elsewhere unless input validation or sanitization is desired at the data entry point, but for this alert, strictly sanitizing at output is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
